### PR TITLE
feat(chat): 실시간 참여자 목록 동기화 기능 구현

### DIFF
--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -1,4 +1,3 @@
-import time
 from typing import Any, List, cast
 
 from fastapi import HTTPException, status
@@ -251,6 +250,8 @@ async def leave_chat_room(room_id: int, user: UserModel):
             room_id=room_id, user=user
         ).prefetch_related("user", "riot_account")
 
+        user_id_to_leave = participant.user.id
+
         # Delete participant from DB and close their WebSocket
         await participant.delete()
         await manager.disconnect_user(str(room_id), user_id_to_leave)
@@ -273,6 +274,8 @@ async def kick_participant(room_id: int, participant_id: int, owner: UserModel):
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Owner cannot kick themselves.",
             )
+
+        user_id_to_kick = participant_to_kick.user.id
 
         # Delete participant from DB and close their WebSocket
         await participant_to_kick.delete()

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -251,21 +251,9 @@ async def leave_chat_room(room_id: int, user: UserModel):
             room_id=room_id, user=user
         ).prefetch_related("user", "riot_account")
 
-        user_id_to_leave = participant.user.id
-        username_to_leave = participant.riot_account.game_name
-
         # Delete participant from DB and close their WebSocket
         await participant.delete()
         await manager.disconnect_user(str(room_id), user_id_to_leave)
-
-        # Broadcast a leave message to the room
-        leave_message = {
-            "type": "user_leave",
-            "user_id": user_id_to_leave,
-            "username": username_to_leave,
-            "timestamp": time.time(),
-        }
-        await manager.broadcast(leave_message, str(room_id))
 
     except DoesNotExist:
         raise HTTPException(
@@ -286,21 +274,9 @@ async def kick_participant(room_id: int, participant_id: int, owner: UserModel):
                 detail="Owner cannot kick themselves.",
             )
 
-        user_id_to_kick = participant_to_kick.user.id
-        username_to_kick = participant_to_kick.riot_account.game_name
-
         # Delete participant from DB and close their WebSocket
         await participant_to_kick.delete()
         await manager.disconnect_user(str(room_id), user_id_to_kick)
-
-        # Broadcast a leave message to the room
-        leave_message = {
-            "type": "user_leave",
-            "user_id": user_id_to_kick,
-            "username": username_to_kick,
-            "timestamp": time.time(),
-        }
-        await manager.broadcast(leave_message, str(room_id))
 
     except DoesNotExist:
         raise HTTPException(

--- a/app/services/connection_manager.py
+++ b/app/services/connection_manager.py
@@ -40,7 +40,9 @@ class ConnectionManager:
             await websocket.close(code=status.WS_1000_NORMAL_CLOSURE)
             self.disconnect(room_id, user_id)
 
-    async def broadcast(self, message: dict, room_id: str, save_to_history: bool = True):
+    async def broadcast(
+        self, message: dict, room_id: str, save_to_history: bool = True
+    ):
         # Store message in history if requested
         if save_to_history:
             self.history[room_id].append(message)

--- a/app/services/connection_manager.py
+++ b/app/services/connection_manager.py
@@ -40,13 +40,15 @@ class ConnectionManager:
             await websocket.close(code=status.WS_1000_NORMAL_CLOSURE)
             self.disconnect(room_id, user_id)
 
-    async def broadcast(self, message: dict, room_id: str):
-        # Store message in history before broadcasting
-        self.history[room_id].append(message)
+    async def broadcast(self, message: dict, room_id: str, save_to_history: bool = True):
+        # Store message in history if requested
+        if save_to_history:
+            self.history[room_id].append(message)
 
         if room_id in self.active_connections:
+            message_str = json.dumps(message, ensure_ascii=False)
             for user_id, connection in self.active_connections[room_id].items():
-                await connection.send_text(json.dumps(message))
+                await connection.send_text(message_str)
 
     def get_active_user_count(self, room_id: str) -> int:
         if room_id in self.active_connections:


### PR DESCRIPTION
기존에는 사용자가 채팅방에 접속하거나 나갈 때, 프론트엔드가 join/leave 이벤트를 받고 참여자 목록을 다시 API로 요청해야 했습니다.

이번 변경으로 웹소켓 로직을 개선하여, 참여자 목록에 변동이 생길 때마다 백엔드가 항상 최신 전체 참여자 목록을 포함한 방 정보를 모든 클라이언트에게 직접 푸시(push)하도록 수정했습니다.

주요 변경 사항:
- `chat_router`: 웹소켓 `connect` 및 `disconnect` 시, `chat_service.get_chat_room_details`를 호출하여 방의 최신 정보를 가져온 뒤, `participants_update` 타입으로 브로드캐스트합니다.
- `ConnectionManager`: `broadcast` 메서드에 `save_to_history` 파라미터를 추가하여, 참여자 목록 업데이트와 같은 비채팅성 메시지는 대화 기록에 저장되지 않도록 수정했습니다.
- 기대 효과: 프론트엔드는 단순히 `participants_update` 이벤트를 수신하여 화면을 다시 그리기만 하면 되므로, 로직이 단순해지고 데이터 정합성이 보장됩니다.