### PR TITLE
✨ feat: chat_router.py websoket connect시에 access_token get 기능 구현

### DIFF
--- a/app/apis/v1/chat_router.py
+++ b/app/apis/v1/chat_router.py
@@ -141,6 +141,12 @@ async def get_participant_from_token(
 async def websocket_endpoint(
     websocket: WebSocket, room_id: int, token: Optional[str] = Query(None)
 ):
+
+    # 쿠키 우선 시도
+    cookie_token = websocket.cookies.get("access_token")
+    if not token and cookie_token:
+        token = cookie_token
+
     if not token:
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return


### PR DESCRIPTION
 프론트와 통신후 웹소켓 연결시에 엑세스 토큰을 가져오지 못하는 이슈 발생

솔루션
cookie_token = websocket.cookies.get("access_token")
if not token and cookie_token:
    token = cookie_token
